### PR TITLE
Performance improvement

### DIFF
--- a/Firmware/Include/DAP.h
+++ b/Firmware/Include/DAP.h
@@ -345,19 +345,74 @@ __STATIC_FORCEINLINE void PIN_DELAY_SLOW (uint32_t delay) {
 
 // Fixed delay for fast clock generation
 #ifndef DELAY_FAST_CYCLES
-#define DELAY_FAST_CYCLES       0U      // Number of cycles: 0..3
+#define DELAY_FAST_CYCLES        0U    // Not used for fast cycle calculation anymore
 #endif
-__STATIC_FORCEINLINE void PIN_DELAY_FAST (void) {
-#if (DELAY_FAST_CYCLES >= 1U)
+
+#ifndef DELAY_FAST_CYCLES_SWD
+#define DELAY_FAST_CYCLES_SWD    2U    // Number of cycles: 0..3
+#endif
+__STATIC_FORCEINLINE void PIN_DELAY_FAST_SWD (void) {
+#if (DELAY_FAST_CYCLES_SWD >= 1U)
   __NOP();
 #endif
-#if (DELAY_FAST_CYCLES >= 2U)
+#if (DELAY_FAST_CYCLES_SWD >= 2U)
   __NOP();
 #endif
-#if (DELAY_FAST_CYCLES >= 3U)
+#if (DELAY_FAST_CYCLES_SWD >= 3U)
   __NOP();
 #endif
-}
+} /* PIN_DELAY_FAST_SWD */
+
+#ifndef DELAY_FAST_CYCLES_JTAG
+#define DELAY_FAST_CYCLES_JTAG   10U    // Number of cycles: 1..15
+#endif
+__STATIC_FORCEINLINE void PIN_DELAY_FAST_JTAG (void) {
+#if (DELAY_FAST_CYCLES_JTAG >= 1U)
+  __NOP();
+#endif  
+#if (DELAY_FAST_CYCLES_JTAG >= 2U)
+  __NOP();
+#endif  
+#if (DELAY_FAST_CYCLES_JTAG >= 3U)
+  __NOP();
+#endif
+#if (DELAY_FAST_CYCLES_JTAG >= 4U)
+  __NOP();
+#endif
+#if (DELAY_FAST_CYCLES_JTAG >= 5U)
+  __NOP();
+#endif
+#if (DELAY_FAST_CYCLES_JTAG >= 6U)
+  __NOP();
+#endif
+#if (DELAY_FAST_CYCLES_JTAG >= 7U)
+  __NOP();
+#endif
+#if (DELAY_FAST_CYCLES_JTAG >= 8U)
+  __NOP();
+#endif
+#if (DELAY_FAST_CYCLES_JTAG >= 9U)
+  __NOP();
+#endif
+#if (DELAY_FAST_CYCLES_JTAG >= 10U)
+  __NOP();
+#endif
+#if (DELAY_FAST_CYCLES_JTAG >= 11U)
+  __NOP();
+#endif
+#if (DELAY_FAST_CYCLES_JTAG >= 12U)
+  __NOP();
+#endif
+#if (DELAY_FAST_CYCLES_JTAG >= 13U)
+  __NOP();
+#endif
+#if (DELAY_FAST_CYCLES_JTAG >= 14U)
+  __NOP();
+#endif
+#if (DELAY_FAST_CYCLES_JTAG >= 15U)
+  __NOP();
+#endif
+} /* PIN_DELAY_FAST_SWD */
 
 #ifdef  __cplusplus
 }

--- a/Firmware/Source/DAP.c
+++ b/Firmware/Source/DAP.c
@@ -61,40 +61,23 @@ static const char DAP_FW_Ver [] = DAP_FW_VER;
 static void Set_Clock_Delay(uint32_t clock) {
   uint32_t delay;
 
-  // For frequency values in the range from 100 to 200 Hz, 
-  // there is no conversion to the real frequency, "clock_delay" 
-  // is set directly here. With the exception that the "fast_clock" 
-  // setting is used at 100 Hz.
-  if ((clock >= 100) && (clock <= 200))
-  {
-    if (100 == clock)
-    {
-      DAP_Data.fast_clock  = 1U;
-      DAP_Data.clock_delay = 1U;
-    } else {
-      delay = clock - 100;  
-      DAP_Data.fast_clock  = 0U;
-      DAP_Data.clock_delay = delay;
-    }
+  if (clock >= MAX_SWJ_CLOCK(DELAY_FAST_CYCLES)) {
+    DAP_Data.fast_clock  = 1U;
+    DAP_Data.clock_delay = 1U;
   } else {
-    if (clock >= MAX_SWJ_CLOCK(DELAY_FAST_CYCLES)) {
-      DAP_Data.fast_clock  = 1U;
-      DAP_Data.clock_delay = 1U;
+    DAP_Data.fast_clock  = 0U;
+
+    delay = ((CPU_CLOCK/2U) + (clock - 1U)) / clock;
+    if (delay > IO_PORT_WRITE_CYCLES) {
+      delay -= IO_PORT_WRITE_CYCLES;
+      delay  = (delay + (DELAY_SLOW_CYCLES - 1U)) / DELAY_SLOW_CYCLES;
     } else {
-      DAP_Data.fast_clock  = 0U;
-
-      delay = ((CPU_CLOCK/2U) + (clock - 1U)) / clock;
-      if (delay > IO_PORT_WRITE_CYCLES) {
-        delay -= IO_PORT_WRITE_CYCLES;
-        delay  = (delay + (DELAY_SLOW_CYCLES - 1U)) / DELAY_SLOW_CYCLES;
-      } else {
-        delay  = 1U;
-      }
-
-      DAP_Data.clock_delay = delay;
+      delay  = 1U;
     }
-  }    
-}
+
+    DAP_Data.clock_delay = delay;
+  }
+}    
 
 
 // Get DAP Information

--- a/Firmware/Source/DAP.c
+++ b/Firmware/Source/DAP.c
@@ -61,22 +61,39 @@ static const char DAP_FW_Ver [] = DAP_FW_VER;
 static void Set_Clock_Delay(uint32_t clock) {
   uint32_t delay;
 
-  if (clock >= MAX_SWJ_CLOCK(DELAY_FAST_CYCLES)) {
-    DAP_Data.fast_clock  = 1U;
-    DAP_Data.clock_delay = 1U;
-  } else {
-    DAP_Data.fast_clock  = 0U;
-
-    delay = ((CPU_CLOCK/2U) + (clock - 1U)) / clock;
-    if (delay > IO_PORT_WRITE_CYCLES) {
-      delay -= IO_PORT_WRITE_CYCLES;
-      delay  = (delay + (DELAY_SLOW_CYCLES - 1U)) / DELAY_SLOW_CYCLES;
+  // For frequency values in the range from 100 to 200 Hz, 
+  // there is no conversion to the real frequency, "clock_delay" 
+  // is set directly here. With the exception that the "fast_clock" 
+  // setting is used at 100 Hz.
+  if ((clock >= 100) && (clock <= 200))
+  {
+    if (100 == clock)
+    {
+      DAP_Data.fast_clock  = 1U;
+      DAP_Data.clock_delay = 1U;
     } else {
-      delay  = 1U;
+      delay = clock - 100;  
+      DAP_Data.fast_clock  = 0U;
+      DAP_Data.clock_delay = delay;
     }
+  } else {
+    if (clock >= MAX_SWJ_CLOCK(DELAY_FAST_CYCLES)) {
+      DAP_Data.fast_clock  = 1U;
+      DAP_Data.clock_delay = 1U;
+    } else {
+      DAP_Data.fast_clock  = 0U;
 
-    DAP_Data.clock_delay = delay;
-  }
+      delay = ((CPU_CLOCK/2U) + (clock - 1U)) / clock;
+      if (delay > IO_PORT_WRITE_CYCLES) {
+        delay -= IO_PORT_WRITE_CYCLES;
+        delay  = (delay + (DELAY_SLOW_CYCLES - 1U)) / DELAY_SLOW_CYCLES;
+      } else {
+        delay  = 1U;
+      }
+
+      DAP_Data.clock_delay = delay;
+    }
+  }    
 }
 
 
@@ -405,7 +422,6 @@ static uint32_t DAP_SWJ_Pins(const uint8_t *request, uint8_t *response) {
 static uint32_t DAP_SWJ_Clock(const uint8_t *request, uint8_t *response) {
 #if ((DAP_SWD != 0) || (DAP_JTAG != 0))
   uint32_t clock;
-  uint32_t delay;
 
   clock = (uint32_t)(*(request+0) <<  0) |
           (uint32_t)(*(request+1) <<  8) |

--- a/Firmware/Source/JTAG_DP.c
+++ b/Firmware/Source/JTAG_DP.c
@@ -252,7 +252,7 @@ exit:                                                                           
 
 
 #undef  PIN_DELAY
-#define PIN_DELAY() PIN_DELAY_FAST()
+#define PIN_DELAY() PIN_DELAY_FAST_JTAG()
 JTAG_IR_Function(Fast)
 JTAG_TransferFunction(Fast)
 

--- a/Firmware/Source/SW_DP.c
+++ b/Firmware/Source/SW_DP.c
@@ -262,7 +262,7 @@ static uint8_t SWD_Transfer##speed (uint32_t request, uint32_t *data) {         
 
 
 #undef  PIN_DELAY
-#define PIN_DELAY() PIN_DELAY_FAST()
+#define PIN_DELAY() PIN_DELAY_FAST_SWD()
 SWD_TransferFunction(Fast)
 
 #undef  PIN_DELAY


### PR DESCRIPTION
Hello,

I actually just wanted to see what kind of performance you can achieve with the CMSIS-DAP v2 solution
here on MCU-Link hardware. Unfortunately I could not compile the software here because I did not have
the USB license for compiling.

Then it must be a very good, high-performance USB stack if you can not easily release it for a project.
Which I can understand, of course. But no problem, there was still the finished "CMSIS_DAP.hex" file in
the "Objects" folder, which could also be used for the MCU link for testing.

After the first tests, I was very disappointed with the performance, which differs greatly from the original
MCU-Link firmware.

An i.MX RT1175 was used as the target for my measurements, where the program was loaded into the
internal memory of the CPU. The IDE which is used here is CrossWorks for ARM version v4.10.9.

Since the sources of the original NXP firmware of the MCU-Link are not available, an own solution had to
be found. I only used the DAP part of the software here. Furthermore the NXP USB stack from the SDK,
and my own OS.

For the test, I downloaded my application to the target via SWD and JTAG. With the appropriate speed
settings. With a setting of 36MHz, that does not necessarily mean that a clock of 36MHz was generated,
but just that I was able to achieve maximum performance with this setting.

Here are the download speeds as shown by CrossWorks for the various solutions:

```
CMSIS_DAP.hex Firmware
================================
JTAG @ 14 MHz => 300 - 305 KB/s
SWD  @ 36 MHz => 330 - 340 KB/s

MCU-Link Version v3.140
================================
JTAG @ 18 MHz => 475 - 485 KB/s
SWD  @ 40 MHz => 575 - 585 KB/s

Own version
================================
JTAG @ 100 Hz => 475 - 485 KB/s
SWD  @ 100 Hz => 600 - 630 KB/s
```
My software has the special feature that you can set a divider at speeds in the range of 100-200 Hz.
The divider is calculated from the frequency minus 100. At 100, which corresponds to a divider of 0,
the "fast_clock" is used internally.

And through various delay functions for SWD and JTAG, optimal performance could also be achieved
for SWD and JTAG. Accordingly, here is the pull request.

Best regards,
Michael
